### PR TITLE
Remove confusing make update commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help build release check test clean install run logs start restart stop status update update-all lint fmt fix
+.PHONY: help build release check test clean install run logs start restart stop status lint fmt fix
 
 # Default target
 help:
@@ -19,9 +19,6 @@ help:
 	@echo "  make restart  - Restart service"
 	@echo "  make stop     - Stop service"
 	@echo "  make status   - Check service status"
-	@echo ""
-	@echo "  make update   - Update ChezWizper"
-	@echo "  make update-all - Update ChezWizper and Whisper"
 	@echo ""
 	@echo "  make clean    - Clean build artifacts"
 
@@ -74,21 +71,6 @@ stop:
 status:
 	@systemctl --user is-active chezwizper.service >/dev/null 2>&1 && echo "✓ Service is running" || echo "✗ Service is not running"
 	@curl -s http://127.0.0.1:3737/status 2>/dev/null | python3 -m json.tool || echo "✗ API not responding"
-
-# Update commands
-update:
-	@if command -v chezwizper-update >/dev/null 2>&1; then \
-		chezwizper-update; \
-	else \
-		echo "Update command not found. Try: hash -r && chezwizper-update"; \
-	fi
-
-update-all:
-	@if command -v chezwizper-update >/dev/null 2>&1; then \
-		chezwizper-update --whisper; \
-	else \
-		echo "Update command not found. Try: hash -r && chezwizper-update --whisper"; \
-	fi
 
 # Cleanup
 clean:


### PR DESCRIPTION
## Summary
- Remove `make update` and `make update-all` targets from Makefile
- Eliminate confusion between development workflow and user update process
- Users should use `chezwizper-update` command directly (already documented in README)

## Problem Solved
Previously, users could run `make update` from the development directory, which:
- Was confusing (mixed dev/user workflows)
- Tried to update the production installation from dev directory
- Led to git conflicts and sudo authentication issues

## Changes Made
- ✅ Removed `update` and `update-all` targets from Makefile
- ✅ Updated `.PHONY` declaration and help text
- ✅ Verified README already shows correct `chezwizper-update` commands
- ✅ Configuration documentation remains comprehensive

## After This Change
**Clear separation of concerns:**
- **Users:** `chezwizper-update` (handles complete update flow)
- **Developers:** `make build`, `make test`, etc. (development tasks only)

## Test Plan
- [x] Makefile help shows clean command list
- [x] README Updates section shows correct commands
- [x] No broken references to removed commands
- [x] Pre-commit checks pass