### PR TITLE
Fix whisper-cpp provider configuration and auto-detection

### DIFF
--- a/example_config.toml
+++ b/example_config.toml
@@ -4,27 +4,27 @@ sample_rate = 16000
 channels = 1
 
 [whisper]
-# Auto-detection (recommended) - will use the best available provider:
-# 1. OpenAI Whisper CLI (if installed) 
-# 2. whisper.cpp (fallback)
-# Note: API providers need explicit configuration with api_key
-model = "base"
-language = "en"
+# Provider selection (defaults to auto-detection if not specified)
+# Uncomment and set provider to explicitly choose:
+# provider = "whisper-cpp"    # Local whisper.cpp (built during install)
+# provider = "openai-cli"     # Local OpenAI Whisper CLI 
+# provider = "openai-api"     # OpenAI API (requires api_key)
 
-# Explicit provider examples (uncomment to override auto-detection):
-# provider = "openai-api"     # OpenAI API provider
-# api_key = "sk-your-key"     # Your OpenAI API key (required for API)
-# model = "whisper-1"         # For OpenAI API
+# Common settings
+model = "base"              # Model size: tiny, base, small, medium, large-v3, large-v3-turbo
+language = "en"             # Language code (en, es, fr, de, etc.)
+
+# whisper.cpp settings (used when provider = "whisper-cpp")
+# command_path = "/path/to/whisper-cli"  # Optional custom path
+# model_path = "/path/to/model.bin"      # Optional custom model path
+
+# OpenAI CLI settings (used when provider = "openai-cli")
+# command_path = "/path/to/whisper"      # Optional custom path
+
+# OpenAI API settings (used when provider = "openai-api")
+# api_key = "sk-your-key"                # Required for API
+# model = "whisper-1"                    # API model name
 # api_endpoint = "https://api.openai.com/v1/audio/transcriptions"  # Optional
-
-# provider = "openai-cli"     # Local OpenAI Whisper CLI
-# model = "base"              # tiny, base, small, medium, large-v3
-# command_path = "/path/to/whisper"  # Optional custom path
-
-# provider = "whisper-cpp"    # Local whisper.cpp (experimental)
-# model = "base"
-# command_path = "/path/to/whisper"     # Optional custom path  
-# model_path = "/path/to/model.bin"     # Optional custom model
 
 [ui]
 indicator_position = "top-right"

--- a/scripts/install-arch.sh
+++ b/scripts/install-arch.sh
@@ -294,6 +294,7 @@ sample_rate = 16000
 channels = 1
 
 [whisper]
+provider = "whisper-cpp"
 model = "large-v3-turbo"
 language = "en"
 command_path = "$WHISPER_DIR/build/bin/whisper-cli"

--- a/src/whisper/providers/whisper_cpp.rs
+++ b/src/whisper/providers/whisper_cpp.rs
@@ -32,7 +32,10 @@ impl WhisperCppProvider {
                 ));
             }
         } else {
-            which("whisper").context("Whisper CLI not found. Please install whisper.cpp")?
+            // Try to find whisper-cli first (as built by our install script), then whisper
+            which("whisper-cli")
+                .or_else(|_| which("whisper"))
+                .context("Whisper CLI not found. Please install whisper.cpp (whisper-cli or whisper command)")?
         };
 
         info!("Found whisper.cpp at: {:?}", command_path);


### PR DESCRIPTION
## Summary
- Fixed whisper-cpp provider auto-detection to check for both `whisper-cli` and `whisper` commands
- Added explicit `provider = "whisper-cpp"` to the install script's generated config
- Improved example configuration documentation with clearer provider options

## Changes

### 1. Enhanced whisper-cpp command detection
The provider now first looks for `whisper-cli` (as built by our install script) before falling back to `whisper`. This ensures compatibility with both our custom build and standard whisper.cpp installations.

### 2. Explicit provider configuration in install script  
The Arch install script now explicitly sets `provider = "whisper-cpp"` in the generated config to ensure the correct provider is used after installation.

### 3. Improved configuration documentation
Reorganized the example_config.toml to make provider selection clearer:
- Better comments explaining auto-detection vs explicit provider selection
- Grouped provider-specific settings together
- More intuitive organization of configuration options

## Impact
These changes improve the out-of-the-box experience for users installing ChezWizper, especially those using the whisper-cpp provider built during installation.